### PR TITLE
fix: remove cluster arch flag.

### DIFF
--- a/osia/cli.py
+++ b/osia/cli.py
@@ -125,13 +125,8 @@ def _resolve_installer(from_args):
             # fine to run normal installer on FIPS enabled RHEL
             from_args.enable_fips = False
 
-    download_arch = from_args.installer_arch
-    cluster_arch = getattr(from_args, 'cluster_arch', None)
-    if cluster_arch and cluster_arch != from_args.installer_arch:
-        download_arch = 'multi'
-
     return download_installer(from_args.installer_version,
-                              download_arch,
+                              from_args.installer_arch,
                               from_args.installers_dir,
                               from_args.installer_source,
                               rhel_version=rhel_version,
@@ -197,9 +192,6 @@ def _create_commons() -> argparse.ArgumentParser:
         (['--installer-arch'], {"help": 'Architecture of downloader to be downloaded',
                                 "choices": [ARCH_AMD, ARCH_X86_64, ARCH_ARM, ARCH_AARCH64, ARCH_PPC, ARCH_S390X],
                                 "default": ARCH_AMD, "type": str}),
-        (['--cluster-arch'], {"help": 'Architecture of the cluster nodes (overrides --installer-arch for install-config)',
-                              "choices": [ARCH_AMD, ARCH_X86_64, ARCH_ARM, ARCH_AARCH64, ARCH_PPC, ARCH_S390X],
-                              "default": None, "type": str}),
         (['--installer-source'], {"type": str, "help": 'Set the source to search for installer',
                                   "choices": ["prod", "devel", "prev"], "default": 'prod'}),
         (['--installers-dir'], {"help": 'Folder where installers are stored', "required": False,

--- a/osia/config/config.py
+++ b/osia/config/config.py
@@ -82,11 +82,7 @@ def read_config(args: argparse.Namespace, default_args: dict) -> dict:
             {j: i['proc'](vars(args)[j]) for j, i in default_args['install'].items()
              if vars(args)[j] is not None}
         )
-        # Add cluster architecture to cloud configuration
-        # --cluster-arch overrides --installer-arch for the install-config
-        if hasattr(args, 'cluster_arch') and args.cluster_arch is not None:
-            result['cloud']['installer_arch'] = args.cluster_arch
-        elif hasattr(args, 'installer_arch') and args.installer_arch is not None:
+        if hasattr(args, 'installer_arch') and args.installer_arch is not None:
             result['cloud']['installer_arch'] = args.installer_arch
 
         if 'credentials_file' in result['cloud']:
@@ -98,7 +94,7 @@ def read_config(args: argparse.Namespace, default_args: dict) -> dict:
                 "aws_secret_access_key": config["default"]["aws_secret_access_key"],
             })
 
-        if result['dns'] is not None:
+        if result['dns'] is not None and 'conf' in result['dns']:
             result['dns']['conf'].update({
                 'cluster_name': args.cluster_name,
                 'base_domain': result['cloud']['base_domain']

--- a/osia/installer/downloader/install.py
+++ b/osia/installer/downloader/install.py
@@ -81,8 +81,7 @@ def get_url(directory: str, arch: str, fips: bool = False,
 
             if not fips and match.group('platform') == os_name:
                 if (local_arch == match.group('architecture')) \
-                        or (not match.group('architecture')
-                            and (local_arch == arch or arch == 'multi')):
+                        or (local_arch == arch and not match.group('architecture')):
                     installer = lst.url + k.get('href')
                     break
     else:
@@ -112,21 +111,13 @@ def get_devel_url(version: str, arch: str, fips: bool = False,
 def get_prev_url(version: str, arch: str, fips: bool = False,
                  rhel_version: str | None = None) -> tuple[str, str | None]:
     """Returns installer url from dev-preview sources"""
-    base = PREVIEW_ROOT.format(arch) + version + "/"
-    if arch == "multi":
-        _, host_arch = _current_platform()
-        base += host_arch + "/"
-    return get_url(base, arch, fips, rhel_version)
+    return get_url(PREVIEW_ROOT.format(arch) + version + "/", arch, fips, rhel_version)
 
 
 def get_prod_url(version: str, arch: str, fips: bool = False,
                  rhel_version: str | None = None) -> tuple[str, str | None]:
     """Returns installer url from production sources"""
-    base = PROD_ROOT.format(arch) + version + "/"
-    if arch == "multi":
-        _, host_arch = _current_platform()
-        base += host_arch + "/"
-    return get_url(base, arch, fips, rhel_version)
+    return get_url(PROD_ROOT.format(arch) + version + "/", arch, fips, rhel_version)
 
 
 def _extract_tar(buffer: _TemporaryFileWrapper[bytes], target: str) -> Path:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installer selection to use the requested architecture consistently.
  * Prevented installation errors when DNS configuration data is incomplete.
  * Removed inconsistent handling of multi-architecture installer downloads.
* **Changes**
  * The `--cluster-arch` option is no longer available for clean and install commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->